### PR TITLE
.gitignore: Created to ignore .ipynb_checkpoints/ directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints/


### PR DESCRIPTION
So less cruft to look at in git status.
